### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main#53d9149` to `dev-main#9c059fa`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2600,12 +2600,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "53d9149014e9e11ff0eb23220e21546686bbfc86"
+                "reference": "9c059fac356bff97d94130ecdbeef8a4bf8dba44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/53d9149014e9e11ff0eb23220e21546686bbfc86",
-                "reference": "53d9149014e9e11ff0eb23220e21546686bbfc86",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/9c059fac356bff97d94130ecdbeef8a4bf8dba44",
+                "reference": "9c059fac356bff97d94130ecdbeef8a4bf8dba44",
                 "shasum": ""
             },
             "require": {
@@ -2655,7 +2655,7 @@
                 "mockery/mockery": "~1.6.12",
                 "nikic/php-parser": "~5.6.1",
                 "phpunit/phpunit": "~12.3.7",
-                "symfony/var-dumper": "~7.3.2",
+                "symfony/var-dumper": "~7.3.3",
                 "vimeo/psalm": "~6.13.1"
             },
             "default-branch": true,
@@ -2762,7 +2762,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-28T09:41:39+00:00"
+            "time": "2025-08-29T08:40:12+00:00"
         },
         {
             "name": "ghostwriter/psr-phpunit-assertions",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#53d9149` to `dev-main#9c059fa`.

This pull request changes the following file(s): 

- Update `composer.lock`