### PR TITLE
Update ghostwriter/shell to version 0.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/json": "^3.0.1",
         "ghostwriter/option": "^2.0.0",
         "ghostwriter/result": "^2.0.0",
-        "ghostwriter/shell": "^0.1.1",
+        "ghostwriter/shell": "^0.1.2",
         "ghostwriter/uuid": "^1.0.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6fc7d2324c451904bef65a3bed47c083",
+    "content-hash": "8bd446d5e5c88cdf44b048bc75010131",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -663,16 +663,16 @@
         },
         {
             "name": "ghostwriter/shell",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/shell.git",
-                "reference": "c50dccf80a93d257557de76cf25e6f2be7fbc3b9"
+                "reference": "e6367b96cd6be790291bc23c1e5d3aa607335109"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/c50dccf80a93d257557de76cf25e6f2be7fbc3b9",
-                "reference": "c50dccf80a93d257557de76cf25e6f2be7fbc3b9",
+                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/e6367b96cd6be790291bc23c1e5d3aa607335109",
+                "reference": "e6367b96cd6be790291bc23c1e5d3aa607335109",
                 "shasum": ""
             },
             "require": {
@@ -683,11 +683,15 @@
                 "ghostwriter/coding-standard": "dev-main",
                 "ghostwriter/container": "^6.0.1",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.4",
-                "symfony/var-dumper": "^7.3.5"
+                "phpunit/phpunit": "^12.5.7",
+                "symfony/var-dumper": "^8.0.3"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/ghostwriter/shell",
+                    "name": "ghostwriter/shell"
+                },
                 "ghostwriter": {
                     "container": {
                         "definition": "Ghostwriter\\Shell\\Container\\ShellDefinition"
@@ -701,7 +705,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-4-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -730,7 +734,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-25T19:01:49+00:00"
+            "time": "2026-01-25T08:43:34+00:00"
         },
         {
             "name": "ghostwriter/uuid",


### PR DESCRIPTION
Updates the `ghostwriter/shell` dependency from `0.1.1` to `0.1.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`