### PR TITLE
Update `boundwize/structarmed` to version `0.9.5`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.9.4",
+        "boundwize/structarmed": "^0.9.5",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4b0a118fbf1c652ed1238e94a9cc2cc",
+    "content-hash": "b0df50299c1b4699b05cd0ccc2d1c389",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1047,16 +1047,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.9.4",
+            "version": "0.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "3aa9c9becd4c87a9911c0a5fe28aefb5f003fbcf"
+                "reference": "4c62dc582322ef9267d02bb81e9ba88e3ef963e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3aa9c9becd4c87a9911c0a5fe28aefb5f003fbcf",
-                "reference": "3aa9c9becd4c87a9911c0a5fe28aefb5f003fbcf",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/4c62dc582322ef9267d02bb81e9ba88e3ef963e0",
+                "reference": "4c62dc582322ef9267d02bb81e9ba88e3ef963e0",
                 "shasum": ""
             },
             "require": {
@@ -1109,7 +1109,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.9.4"
+                "source": "https://github.com/boundwize/structarmed/tree/0.9.5"
             },
             "funding": [
                 {
@@ -1117,7 +1117,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T06:31:44+00:00"
+            "time": "2026-06-01T07:01:44+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.9.4` to `0.9.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`