### PR TITLE
Update `boundwize/structarmed` to version `0.10.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.10.0",
+        "boundwize/structarmed": "^0.10.1",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05ff9f33db7f066542417918d999432e",
+    "content-hash": "7849a4349d27ef8aab580a0fdd3d26bb",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1047,16 +1047,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "5e488b5c1502a92e3cef8cf25b87b77e877b9804"
+                "reference": "7c9b0b47f7e5c715457be498c22476120df4ab84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/5e488b5c1502a92e3cef8cf25b87b77e877b9804",
-                "reference": "5e488b5c1502a92e3cef8cf25b87b77e877b9804",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7c9b0b47f7e5c715457be498c22476120df4ab84",
+                "reference": "7c9b0b47f7e5c715457be498c22476120df4ab84",
                 "shasum": ""
             },
             "require": {
@@ -1109,7 +1109,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.10.0"
+                "source": "https://github.com/boundwize/structarmed/tree/0.10.1"
             },
             "funding": [
                 {
@@ -1117,7 +1117,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T18:39:11+00:00"
+            "time": "2026-06-02T13:40:20+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.10.0` to `0.10.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`